### PR TITLE
chore: trigger Enforce License Compliance workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<!-- trigger: enforce-license-compliance workflow -->
 # Codecov ATS Docker
 
 ## Purpose


### PR DESCRIPTION
Minimal README-only change to run the org FOSSA license compliance workflow on this repository.